### PR TITLE
⚡ Optimize backdrop-filter for performance

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,12 +29,19 @@
 
         .container {
             max-width: 800px;
-            background: rgba(30, 20, 15, 0.85);
-            backdrop-filter: blur(10px);
+            background: rgba(30, 20, 15, 0.95);
             border: 2px solid #8b6f47;
             border-radius: 8px;
             padding: 40px;
             box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+        }
+
+        @media (prefers-reduced-transparency: no-preference) {
+            .container {
+                background: rgba(30, 20, 15, 0.85);
+                backdrop-filter: blur(10px);
+                -webkit-backdrop-filter: blur(10px);
+            }
         }
 
         h1 {


### PR DESCRIPTION
Wraps the expensive backdrop-filter effect in a @media (prefers-reduced-transparency: no-preference) query. Provides a fallback with increased background opacity (0.95) for devices that prefer reduced transparency or lack support.

---
*PR created automatically by Jules for task [3509150367916515180](https://jules.google.com/task/3509150367916515180) started by @josephburt*